### PR TITLE
type alias

### DIFF
--- a/include/engine-m/matrix/matrix.h
+++ b/include/engine-m/matrix/matrix.h
@@ -70,4 +70,6 @@ namespace EngineM {
 
         ~Matrix() = default;
     };
+
+    using mat3 = Matrix;
 }

--- a/include/engine-m/vector/vector2d.h
+++ b/include/engine-m/vector/vector2d.h
@@ -49,4 +49,6 @@ namespace EngineM {
 
         ~Vector2d() override = default;
     };
+
+    using vec2 = Vector2d;
 }

--- a/include/engine-m/vector/vector2d.h
+++ b/include/engine-m/vector/vector2d.h
@@ -2,7 +2,6 @@
 
 #include "engine-m/core.h"
 #include "vector.h"
-#include "vector3d.h"
 
 namespace EngineM {
 

--- a/include/engine-m/vector/vector3d.h
+++ b/include/engine-m/vector/vector3d.h
@@ -54,4 +54,6 @@ namespace EngineM {
 
         ~Vector3d() override = default;
     };
+
+    using vec3 = Vector3d;
 }


### PR DESCRIPTION
- **add type aliases for Vector2d, Vector3d and Matrix as vec2, vec3 and mat3**
  

- **remove unnecessary include for Vector3d in Vector2d header**
  